### PR TITLE
Fixing post method on IE

### DIFF
--- a/request.js
+++ b/request.js
@@ -83,7 +83,9 @@
                 methods.always.apply();
             };
             if(method === 'POST'){
-                request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+                if(!window.XDomainRequest){
+                    request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+                }
                 data = utils.toQuery(data);
             }
             if(method === 'GET'){


### PR DESCRIPTION
The method `setRequestHeader` is not present on [XDomainRequest](http://msdn.microsoft.com/en-us/library/ie/cc288060%28v=vs.85%29.aspx#methods);

We should skip call this method to prevent error on IE
