### PR TITLE
Pass the event info to error callback

### DIFF
--- a/request.js
+++ b/request.js
@@ -116,17 +116,19 @@
         return callbacks;
     };
 
-    exports.get = function (url, query) {
+    /*jshint -W069 */
+    exports['get'] = function (url, query) {
         return xhr('GET', url, {}, query);
     };
 
-    exports.put = function (url, data, query) {
+    exports['put'] = function (url, data, query) {
         return xhr('PUT', url, data, query);
     };
 
-    exports.post = function (url, data, query) {
+    exports['post'] = function (url, data, query) {
         return xhr('POST', url, data, query);
     };
+    /*jshint +W069 */
 
     exports['delete'] = function (url, query) {
         return xhr('DELETE', url, {}, query);

--- a/request.js
+++ b/request.js
@@ -9,7 +9,7 @@
 })(this, function (root) {
 
     'use strict';
-    
+
     var exports = {},
         utils = {},
         xhr;
@@ -63,7 +63,7 @@
             request.onprogress = function(){ };
             request.ontimeout = function(){ };
         }else if(window.ActiveXObject){
-            request = new ActiveXObject('Microsoft.XMLHTTP'); 
+            request = new ActiveXObject('Microsoft.XMLHTTP');
         }else if(window.XMLHttpRequest){
             request = new XMLHttpRequest();
         }
@@ -74,14 +74,14 @@
             request.onload = function(){
                 if((request.statusText === 'OK' && request.status === 200) || typeof request.statusText === 'undefined'){
                     methods.success.apply(methods, utils.parse(request));
-                    methods.always.apply();    
+                    methods.always.apply();
                 } else {
                     methods.error.apply(methods, utils.parse(request));
                     methods.always.apply();
                 }
             };
-            request.onerror = function(){
-                methods.error.apply(methods, utils.parse(request));
+            request.onerror = function(e){
+                methods.error.apply(methods, e);
                 methods.always.apply();
             };
             if(method === 'POST'){
@@ -116,15 +116,15 @@
         return callbacks;
     };
 
-    exports['get'] = function (url, query) {
+    exports.get = function (url, query) {
         return xhr('GET', url, {}, query);
     };
 
-    exports['put'] = function (url, data, query) {
+    exports.put = function (url, data, query) {
         return xhr('PUT', url, data, query);
     };
 
-    exports['post'] = function (url, data, query) {
+    exports.post = function (url, data, query) {
         return xhr('POST', url, data, query);
     };
 

--- a/request.js
+++ b/request.js
@@ -73,15 +73,15 @@
             request.open(method, (url.indexOf('http') > -1) ? url : protocol+url, true);
             request.onload = function(){
                 if((request.statusText === 'OK' && request.status === 200) || typeof request.statusText === 'undefined'){
-                    methods.success.apply(methods, utils.parse(request));
+                    methods.success.apply(request, utils.parse(request));
                     methods.always.apply();
                 } else {
-                    methods.error.apply(methods, utils.parse(request));
+                    methods.error.apply(request, utils.parse(request));
                     methods.always.apply();
                 }
             };
             request.onerror = function(e){
-                methods.error.apply(methods, e);
+                methods.error.apply(request, e);
                 methods.always.apply();
             };
             if(method === 'POST'){


### PR DESCRIPTION
# What this PR does

Pass the event info coming from `onerror` to the `error` callback to let the client differentiate if the fail came from an invalid status code or an actual network failure. 
# How to test this

I'm testing this straight on DevKit installing this version instead master
# Review

Please review it using [`w=1`](/Olapic/request/pull/4/files?w=1)
