### PR TITLE
Validate HTTP status

### DIFF
--- a/request.js
+++ b/request.js
@@ -44,6 +44,27 @@
         return result;
     };
 
+    utils.validateHTTPStatus = function(code){
+        var result = false;
+        code = parseInt(code);
+        /*
+        200 OK
+        201 Created
+        202 Accepted
+        203 Non-Authoritative Information (since HTTP/1.1)
+        204 No Content
+        205 Reset Content
+        206 Partial Content
+        207 Multi-Status (WebDAV; RFC 4918)
+        208 Already Reported (WebDAV; RFC 5842)
+        226 IM Used (RFC 3229)
+         */
+        if(code >= 200 && code <230){
+            result = true;
+        }
+        return result;
+    };
+
     xhr = function(method, url, data, query){
         var methods = {
                 success: function(){},
@@ -72,7 +93,7 @@
             if(query) url += ((url.indexOf('?') > -1) ? '&' : '?') + utils.toQuery(query);
             request.open(method, (url.indexOf('http') > -1) ? url : protocol+url, true);
             request.onload = function(){
-                if((request.statusText === 'OK' && request.status === 200) || typeof request.statusText === 'undefined'){
+                if(utils.validateHTTPStatus(request.status) || request.statusText === 'OK' || typeof request.statusText === 'undefined'){
                     methods.success.apply(request, utils.parse(request));
                     methods.always.apply();
                 } else {


### PR DESCRIPTION
#### What does this PR do?

It adds a method to validate a request based on the [HTTP status code](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success).
#### How should this be manually tested?

This snippet uses the report photo form request and it returns a `201`:

``` javascript
.post('http://z4photorankapi-a.akamaihd.net/media/2181780842/reports',{
    email : 'demo@demo.com',
    reason: 'some reason'
},{
    auth_token : 'TOKEN',
    version : 'v2.2',
    count : '16'
});
```
#### Any background context you want to provide?

I know we don't have requests that return statuses others than `200` and `201`, but I wanted it to be as complete as possible.
#### What are the relevant tickets?

[[CS-2341] After reporting a photo, mail and reason fields are not hidden](https://photorank.atlassian.net/browse/CS-2341)
