### PR TITLE
Fix XDomainRequest IF order

### DIFF
--- a/request.js
+++ b/request.js
@@ -80,13 +80,13 @@
             query = utils.verifyQuery(url,query);
         }
 
-        if(window.XMLHttpRequest){
-            request = new XMLHttpRequest();
-            supportHeaders = true;
-        }else if(window.XDomainRequest){
+        if(window.XDomainRequest){
             request = new XDomainRequest();
             request.onprogress = function(){ };
             request.ontimeout = function(){ };
+        }else if(window.XMLHttpRequest){
+            request = new XMLHttpRequest();
+            supportHeaders = true;
         }else if(window.ActiveXObject){
             request = new ActiveXObject('Microsoft.XMLHTTP');
         }


### PR DESCRIPTION
#### What does this PR do?

I messed up on the previous PR; I set `XMLHttpRequest` as first check instead of `XDomainRequest`, and IE9 has `XMLHttpRequest`, but you get `access denied` when you use it for cross domain.
#### How should this be manually tested?
- Without checking out my branch, try some cross domain requests on IE9, they should all fail.
- Do it on my branch.
