### PR TITLE
Fixed data (body) param in POST method being parsed as query string w…

### DIFF
--- a/request.js
+++ b/request.js
@@ -115,7 +115,9 @@
                 if(supportHeaders){
                     request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
                 }
-                data = utils.toQuery(data);
+                if(typeof data !== 'string'){
+                  data = utils.toQuery(data);
+                }
             }
             if(method === 'GET'){
                 data = null;

--- a/request.js
+++ b/request.js
@@ -116,7 +116,7 @@
                     request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
                 }
                 if(typeof data !== 'string'){
-                  data = utils.toQuery(data);
+                    data = utils.toQuery(data);
                 }
             }
             if(method === 'GET'){


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
This PR fix the specific scenario when making a POST request, given the `data` as a string, when `utils.toQuery(data);` was treating the string as an array thus splitting each character and parsing in as query strings.

Any background context you want to provide?
-------------------------------------------
This change is necessary for using the POST method with a valid body (`data` var) as a JSON string. In particular, we are currently implementing this case in the SDK error tracker.

What are the relevant tickets?
------------------------------
[SDK Error tracking MVP](https://photorank.atlassian.net/browse/SDKJS-104)

Any extra info?
---------------
N/A

Any related PRs?
---------------
